### PR TITLE
[FIX] - Error on npm run start

### DIFF
--- a/src/enums/languages.js
+++ b/src/enums/languages.js
@@ -1,0 +1,8 @@
+
+module.exports = {
+    ES_AR: 'es-AR',
+    EN_US: 'en-US',
+    PT_BR: 'pt-BR',
+    DE_DE: 'de-DE',
+  };
+  

--- a/src/scenes/MenuPrincipal.js
+++ b/src/scenes/MenuPrincipal.js
@@ -1,4 +1,6 @@
 import Phaser from "phaser";
+import { EN_US, ES_AR } from "../enums/languages";
+import { getTranslations } from "../services/translations";
 
 export default class MenuPrincipal extends Phaser.Scene {
   constructor() {
@@ -40,7 +42,6 @@ export default class MenuPrincipal extends Phaser.Scene {
 
   async getTranslations(language){
     this.language = language;
-    this.#wasChangedLanguage = FETCHING;
     
     await getTranslations(language) }
 }


### PR DESCRIPTION
El problema se debía a que no existía la propiedad `#wasChangedLanguage` en la scene, ademas de que no existían las constantes de los lenguajes y no estaba importada la función `getTranslations`.

Para solucionarlo:

1. agregar las enums
2. eliminar la propiedad que no se usaba, y no se declaraba
3. importar la función

Como extra, el texto no se muestra centrado, podes ver como mejorarlo con esta [herramienta](https://ourcade.co/tools/phaser3-text-styler/). 
Del lado derecho existen un montón de propiedades que se le puede dar al texto, del lado izquierdo arriba se ve el resultado y debajo el código!